### PR TITLE
Permute axis method in AbacusSTRU and AbacusATOM

### DIFF
--- a/abacustest/lib_prepare/abacus.py
+++ b/abacustest/lib_prepare/abacus.py
@@ -524,24 +524,12 @@ class AbacusStru:
     @staticmethod
     def mag_to_angle(magx,magy,magz):
         '''return the angle1 and angle2 of the magnetization'''
-        mag = np.array([magx,magy,magz])
-        mag /= np.linalg.norm(mag)
-        angle1 = np.arccos(mag[2]) * 180 / np.pi
-        angle2 = np.arctan2(mag[1],mag[0]) * 180 / np.pi
-        return angle1,angle2
+        return comm.mag_to_angle(magx,magy,magz)
     
     @staticmethod
     def angle_to_mag(totmag,angle1,angle2):
         '''return the magnetization of the magnetization'''
-        if angle1 is None:
-            angle1 = 0
-        if angle2 is None:
-            angle2 = 0
-        angle1 = angle1 * np.pi / 180
-        angle2 = angle2 * np.pi / 180
-        mag = np.array([np.sin(angle1)*np.cos(angle2),np.sin(angle1)*np.sin(angle2),np.cos(angle1)])
-        mag *= totmag
-        return mag.tolist()
+        return comm.angle_to_mag(totmag,angle1,angle2)
         
     
     def get_mag(self):

--- a/abacustest/lib_prepare/comm.py
+++ b/abacustest/lib_prepare/comm.py
@@ -376,4 +376,23 @@ def pert_vector(vectors:List[List[float]],max_angle):
     for ivector in vectors:
         new_vectors.append(np.dot(R_matrix,ivector).tolist())
     return new_vectors
-        
+
+def mag_to_angle(magx,magy,magz):
+    '''return the angle1 and angle2 of the magnetization'''
+    mag = np.array([magx,magy,magz])
+    mag /= np.linalg.norm(mag)
+    angle1 = np.arccos(mag[2]) * 180 / np.pi
+    angle2 = np.arctan2(mag[1],mag[0]) * 180 / np.pi
+    return angle1,angle2
+
+def angle_to_mag(totmag,angle1,angle2):
+    '''return the magnetization of the magnetization'''
+    if angle1 is None:
+        angle1 = 0
+    if angle2 is None:
+        angle2 = 0
+    angle1 = angle1 * np.pi / 180
+    angle2 = angle2 * np.pi / 180
+    mag = np.array([np.sin(angle1)*np.cos(angle2),np.sin(angle1)*np.sin(angle2),np.cos(angle1)])
+    mag *= totmag
+    return mag.tolist()

--- a/abacustest/lib_prepare/stru.py
+++ b/abacustest/lib_prepare/stru.py
@@ -145,36 +145,36 @@ class AbacusATOM(BaseModel):
         c += f"Real atomic mag/magnitude: {self.atommag} / {self.atommag_magnitude}\n"
         return c
 
-    def _permute_coord(self, mode: Literal["bca", "cab"]):
+    def _permute_coord(self, mode=Literal["yzx", "zxy"]):
         """
         Update properties including coord, mag (for non-collinear case) and velocity of an atom during permuting axis.
         """
-        if mode == "bca":
+        if mode == "yzx":
+            trans_mat = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+        elif mode == "zxy":
             trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
-        elif mode == "cab":
-            trans_mat = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
         else:
             raise ValueError(f"Invalid mode: {mode}")
         
         # permute coord
-        self.coord = np.dot(trans_mat, np.array(self.coord))
+        self.coord = np.dot(np.array(self.coord).T, trans_mat)
         
         # permute velocity
         if self.velocity is not None:
-            self.velocity = np.dot(trans_mat, np.array(self.velocity))
+            self.velocity = np.dot(np.array(self.velocity), trans_mat)
         
         # permute move
-        if mode == "bca":
+        if mode == "yzx":
             self.move = (self.move[1], self.move[2], self.move[0])
-        elif mode == "cab":
+        elif mode == "zxy":
             self.move = (self.move[2], self.move[0], self.move[1])
         
         # permute non-collinear mag
         if self.angle1 is not None and self.angle2 is not None:
-            if mode == "bca":
+            if mode == "yzx":
                 self.angle1 = np.arccos(np.sin(self.angle1) * np.cos(self.angle2))
                 self.angle2 = np.arctan2(np.cos(self.angle1), np.sin(self.angle1) * np.sin(self.angle2))
-            elif mode == "cab":
+            elif mode == "zxy":
                 self.angle1 = np.arccos(np.sin(self.angle1) * np.sin(self.angle2))
                 self.angle2 = np.arctan2(np.sin(self.angle1) * np.cos(self.angle2), np.cos(self.angle1))
 
@@ -919,11 +919,9 @@ class AbacusSTRU:
                 elif only:
                     self._atoms[i].move = (True, True, True)
     
-    def permute_axis(self, mode=Literal["bca", "cab"]):
+    def permute_lat_vec(self, mode=Literal["bca", "cab"]):
         """
         Permute the axis of the structure.
-        Properties including cell, coords, velocity and atom mag (non-collinear case) will also be updated.
-
         Args:
             mode (str): The mode of permuting axis. Can be "bca" or "cab", which means transform from "abc" to "bca" or "cab".
         """
@@ -935,8 +933,25 @@ class AbacusSTRU:
             raise ValueError(f"Invalid mode: {mode}")
         
         self.cell = np.dot(trans_mat, self.cell)
+    
+    def permute_coord(self, mode=Literal["yzx", "zxy"]):
+        """
+        Permute the coordinates of the structure.
+        Properties including cell, coords, velocity and atom mag (non-collinear case) will also be updated.
+
+        Args:
+            mode (str): The mode of permuting coordinates. Can be "yzx" or "zxy", which means transform from "xyz" to "yzx" or "zxy".
+        """
+        if mode == "yzx":
+            trans_mat = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+        elif mode == "zxy":
+            trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+        
+        self.cell = np.dot(self.cell, trans_mat)
         for i in range(len(self._atoms)):
-            self._atoms[i]._permute_axis(mode=mode)
+            self._atoms[i]._permute_coord(mode=mode)
 
 
 def parse_stru_position(pos_line):

--- a/abacustest/lib_prepare/stru.py
+++ b/abacustest/lib_prepare/stru.py
@@ -4,7 +4,7 @@ import numpy as np
 import copy
 
 from abacustest.constant import MASS_DICT, A2BOHR, BOHR2A, ABACUS_STRU_KEY_WORD
-from abacustest.lib_prepare.comm import Cartesian2Direct, Direct2Cartesian
+from abacustest.lib_prepare.comm import Cartesian2Direct, Direct2Cartesian, mag_to_angle, angle_to_mag
 
 import traceback
 import os
@@ -115,9 +115,9 @@ class AbacusATOM(BaseModel):
     constrain: Optional[Union[bool, Tuple[bool, bool, bool]]] = None
     lambda_: Optional[Union[float, Tuple[float, float, float]]] = None
 
-    mag: Optional[Union[float, Tuple[float, float, float]]] = Field(default=None, frozen=True)  # magnitude of magnetic moment
-    angle1: Optional[float] = Field(default=None, frozen=True)  # angle between magnetic moment and z-axis
-    angle2: Optional[float] = Field(default=None, frozen=True)  # angle between projection of magnetic moment on xy-plane and x-axis
+    mag: Optional[Union[float, Tuple[float, float, float]]] = None  # magnitude of magnetic moment
+    angle1: Optional[float] =  None  # angle between magnetic moment and z-axis
+    angle2: Optional[float] =  None  # angle between projection of magnetic moment on xy-plane and x-axis
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -144,17 +144,6 @@ class AbacusATOM(BaseModel):
         c += f"Constrain: {self.constrain}, Lambda: {self.lambda_}\n"
         c += f"Real atomic mag/magnitude: {self.atommag} / {self.atommag_magnitude}\n"
         return c
-
-    def _rotate_cart_coord(self, rot_mat: np.ndarray):
-        """
-        Rotate the cartesian coordinates of an atom. Related properties, including velocity will be updated.
-        """
-        # Rotate cartesian coordinate
-        self.coord = tuple(np.dot(rot_mat, np.array(self.coord)))
-
-        # Rotate velocity
-        if self.velocity is not None:
-            self.velocity = tuple(np.dot(rot_mat, np.array(self.velocity)))
 
     @property
     def atomtype(self) -> AbacusAtomType:
@@ -199,7 +188,7 @@ class AbacusATOM(BaseModel):
         """
         import numpy as np
         if self.noncolinear:
-            mag_norm = self.atommag_moment
+            mag_norm = self.mag
             angle1 = angle2 = 0.0
             if self.angle1 is not None:
                 angle1 = self.angle1    
@@ -214,6 +203,21 @@ class AbacusATOM(BaseModel):
                 return self.type_mag
             else:
                 return self.mag
+    
+    def mag_angle(self):
+        # Calculate angle of noncollinear magnetic moment
+        if self.noncolinear:
+            if self.angle1 is None and self.angle2 is None:
+                angle1, angle2 = mag_to_angle(*self.mag)
+            else:
+                angle1, angle2 = 0, 0
+                if self.angle1:
+                    angle1 = self.angle1
+                if self.angle2:
+                    angle2 = self.angle2
+            return (angle1, angle2)
+        else:
+            return (None, None)
 
     def set_atommag(self, mag: Union[float,Tuple[float,float,float]],
                     angle1: float = None,
@@ -229,6 +233,12 @@ class AbacusATOM(BaseModel):
         """
         if isinstance(mag, (list, tuple)):
             assert len(mag) == 3, f"Magnetic moment tuple must have three components, got {mag}."
+        elif isinstance(mag, np.ndarray):
+            mag = mag.tolist()
+        elif isinstance(mag, (int, float)):
+            pass
+        else:
+            raise TypeError("Magnetic moment must be float or tuple of three floats")
 
         self.mag = mag
         self.angle1 = angle1
@@ -307,6 +317,29 @@ class AbacusATOM(BaseModel):
             if atomlist[i].atomtype != atomlist[0].atomtype:
                 return False
         return True
+    
+    def rotate(self, rot_mat: np.ndarray):
+        """
+        Rotate the cartesian coordinates of an atom. Related properties, including velocity will be updated.
+        """
+        # Rotate cartesian coordinate
+        self.coord = tuple(np.dot(rot_mat, np.array(self.coord)))
+
+        # Rotate velocity
+        if self.velocity is not None:
+            self.velocity = tuple(np.dot(rot_mat, np.array(self.velocity)))
+        
+        # Rotate non-collinear magnetic moment
+        if self.noncolinear:
+            new_mag = np.dot(rot_mat, np.array(self.atommag))
+            if self.angle1 is None or self.angle2 is None:
+                self.set_atommag(new_mag.tolist())
+            else:
+                angle1, angle2 = mag_to_angle(*new_mag)
+                self.set_atommag(np.linalg.norm(new_mag).tolist(),
+                                 angle1,
+                                 angle2)
+
 
 class AbacusSTRU:
     """ABACUS STRU class
@@ -853,7 +886,7 @@ class AbacusSTRU:
         # rotate the cell using given rotation matric
         self.cell = np.dot(rot_mat, np.array(self.cell).T).T.tolist()
         for i in range(len(self._atoms)):
-            self._atoms[i]._rotate_cart_coord(rot_mat)
+            self._atoms[i].rotate(rot_mat)
 
     def fix_atom_by_index(self, indices: List[int],
                           move: Optional[Tuple[bool, bool, bool]] = (False, False, False),
@@ -1301,6 +1334,8 @@ def write_stru_file(
             cc += "%17.11f %17.11f %17.11f " % tuple(coord[icoord + j])
             if move and move[icoord + j] and len(move[icoord + j]) == 3:
                 cc += "%d %d %d " % tuple(move[icoord + j])
+            if velocity and velocity[icoord + j] and len(velocity[icoord + j]) == 3:
+                cc += "v %f %f %f " % tuple(velocity[icoord + j])
             if magmom and magmom[icoord + j] is not None:
                 if isinstance(magmom[icoord + j],list):
                     if len(magmom[icoord + j]) == 3:
@@ -1309,8 +1344,6 @@ def write_stru_file(
                         cc += "mag %12.8f " % magmom[icoord + j][0]
                 elif magmom[icoord + j] != None:
                     cc += "mag %12.8f " % magmom[icoord + j]
-            if velocity and velocity[icoord + j] and len(velocity[icoord + j]) == 3:
-                cc += "v %f %f %f " % tuple(velocity[icoord + j])
             if angle1 and angle1[icoord + j] != None:
                     cc += "angle1 %f " % angle1[icoord + j]
             if angle2 and angle2[icoord + j] != None:

--- a/abacustest/lib_prepare/stru.py
+++ b/abacustest/lib_prepare/stru.py
@@ -145,7 +145,7 @@ class AbacusATOM(BaseModel):
         c += f"Real atomic mag/magnitude: {self.atommag} / {self.atommag_magnitude}\n"
         return c
 
-    def _permute_axis(self, mode: Literal["bca", "cab"]):
+    def _permute_coord(self, mode: Literal["bca", "cab"]):
         """
         Update properties including coord, mag (for non-collinear case) and velocity of an atom during permuting axis.
         """
@@ -158,7 +158,7 @@ class AbacusATOM(BaseModel):
         
         # permute coord
         self.coord = np.dot(trans_mat, np.array(self.coord))
-
+        
         # permute velocity
         if self.velocity is not None:
             self.velocity = np.dot(trans_mat, np.array(self.velocity))
@@ -930,7 +930,7 @@ class AbacusSTRU:
         if mode == "bca":
             trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
         elif mode == "cab":
-            trans_mat = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+            trans_mat = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
         else:
             raise ValueError(f"Invalid mode: {mode}")
         

--- a/abacustest/lib_prepare/stru.py
+++ b/abacustest/lib_prepare/stru.py
@@ -145,6 +145,40 @@ class AbacusATOM(BaseModel):
         c += f"Real atomic mag/magnitude: {self.atommag} / {self.atommag_magnitude}\n"
         return c
 
+    def _permute_axis(self, mode: Literal["bca", "cab"]):
+        """
+        Update properties including coord, mag (for non-collinear case) and velocity of an atom during permuting axis.
+        """
+        if mode == "bca":
+            trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+        elif mode == "cab":
+            trans_mat = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+        
+        # permute coord
+        self.coord = np.dot(trans_mat, np.array(self.coord))
+
+        # permute velocity
+        if self.velocity is not None:
+            self.velocity = np.dot(trans_mat, np.array(self.velocity))
+        
+        # permute move
+        if mode == "bca":
+            self.move = (self.move[1], self.move[2], self.move[0])
+        elif mode == "cab":
+            self.move = (self.move[2], self.move[0], self.move[1])
+        
+        # permute non-collinear mag
+        if self.angle1 is not None and self.angle2 is not None:
+            if mode == "bca":
+                self.angle1 = np.arccos(np.sin(self.angle1) * np.cos(self.angle2))
+                self.angle2 = np.arctan2(np.cos(self.angle1), np.sin(self.angle1) * np.sin(self.angle2))
+            elif mode == "cab":
+                self.angle1 = np.arccos(np.sin(self.angle1) * np.sin(self.angle2))
+                self.angle2 = np.arctan2(np.sin(self.angle1) * np.cos(self.angle2), np.cos(self.angle1))
+
+        
     @property
     def atomtype(self) -> AbacusAtomType:
         """Get the AbacusAtomType object for this atom."""
@@ -884,7 +918,25 @@ class AbacusSTRU:
                     self._atoms[i].move = move
                 elif only:
                     self._atoms[i].move = (True, True, True)
+    
+    def permute_axis(self, mode=Literal["bca", "cab"]):
+        """
+        Permute the axis of the structure.
+        Properties including cell, coords, velocity and atom mag (non-collinear case) will also be updated.
 
+        Args:
+            mode (str): The mode of permuting axis. Can be "bca" or "cab", which means transform from "abc" to "bca" or "cab".
+        """
+        if mode == "bca":
+            trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+        elif mode == "cab":
+            trans_mat = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+        
+        self.cell = np.dot(trans_mat, self.cell)
+        for i in range(len(self._atoms)):
+            self._atoms[i]._permute_axis(mode=mode)
 
 
 def parse_stru_position(pos_line):

--- a/abacustest/lib_prepare/stru.py
+++ b/abacustest/lib_prepare/stru.py
@@ -145,40 +145,17 @@ class AbacusATOM(BaseModel):
         c += f"Real atomic mag/magnitude: {self.atommag} / {self.atommag_magnitude}\n"
         return c
 
-    def _permute_coord(self, mode=Literal["yzx", "zxy"]):
+    def _rotate_cart_coord(self, rot_mat: np.ndarray):
         """
-        Update properties including coord, mag (for non-collinear case) and velocity of an atom during permuting axis.
+        Rotate the cartesian coordinates of an atom. Related properties, including velocity will be updated.
         """
-        if mode == "yzx":
-            trans_mat = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
-        elif mode == "zxy":
-            trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
-        
-        # permute coord
-        self.coord = np.dot(np.array(self.coord).T, trans_mat)
-        
-        # permute velocity
-        if self.velocity is not None:
-            self.velocity = np.dot(np.array(self.velocity), trans_mat)
-        
-        # permute move
-        if mode == "yzx":
-            self.move = (self.move[1], self.move[2], self.move[0])
-        elif mode == "zxy":
-            self.move = (self.move[2], self.move[0], self.move[1])
-        
-        # permute non-collinear mag
-        if self.angle1 is not None and self.angle2 is not None:
-            if mode == "yzx":
-                self.angle1 = np.arccos(np.sin(self.angle1) * np.cos(self.angle2))
-                self.angle2 = np.arctan2(np.cos(self.angle1), np.sin(self.angle1) * np.sin(self.angle2))
-            elif mode == "zxy":
-                self.angle1 = np.arccos(np.sin(self.angle1) * np.sin(self.angle2))
-                self.angle2 = np.arctan2(np.sin(self.angle1) * np.cos(self.angle2), np.cos(self.angle1))
+        # Rotate cartesian coordinate
+        self.coord = tuple(np.dot(rot_mat, np.array(self.coord)))
 
-        
+        # Rotate velocity
+        if self.velocity is not None:
+            self.velocity = tuple(np.dot(rot_mat, np.array(self.velocity)))
+
     @property
     def atomtype(self) -> AbacusAtomType:
         """Get the AbacusAtomType object for this atom."""
@@ -871,6 +848,12 @@ class AbacusSTRU:
                             magnetic_moments=self.atom_mags)
         else:
             raise ValueError(f"Unsupported format: {fmt}")
+    
+    def rotate(self, rot_mat):
+        # rotate the cell using given rotation matric
+        self.cell = np.dot(rot_mat, np.array(self.cell).T).T.tolist()
+        for i in range(len(self._atoms)):
+            self._atoms[i]._rotate_cart_coord(rot_mat)
 
     def fix_atom_by_index(self, indices: List[int],
                           move: Optional[Tuple[bool, bool, bool]] = (False, False, False),
@@ -919,11 +902,11 @@ class AbacusSTRU:
                 elif only:
                     self._atoms[i].move = (True, True, True)
     
-    def permute_lat_vec(self, mode=Literal["bca", "cab"]):
+    def permute_lat_vec(self, mode=Literal["bca", "cab"], rotate_cart_coord=False):
         """
         Permute the axis of the structure.
         Args:
-            mode (str): The mode of permuting axis. Can be "bca" or "cab", which means transform from "abc" to "bca" or "cab".
+            mode (str): The mode of permuting axis. Can be "bca" or "cab", which means transform from (\vec{a}, \vec{b}, \vec{c}).T to (\vec{b}, \vec{c}, \vec{a}).T or (\vec{c}, \vec{a}, \vec{b}).T).
         """
         if mode == "bca":
             trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
@@ -933,26 +916,12 @@ class AbacusSTRU:
             raise ValueError(f"Invalid mode: {mode}")
         
         self.cell = np.dot(trans_mat, self.cell)
-    
-    def permute_coord(self, mode=Literal["yzx", "zxy"]):
-        """
-        Permute the coordinates of the structure.
-        Properties including cell, coords, velocity and atom mag (non-collinear case) will also be updated.
 
-        Args:
-            mode (str): The mode of permuting coordinates. Can be "yzx" or "zxy", which means transform from "xyz" to "yzx" or "zxy".
-        """
-        if mode == "yzx":
-            trans_mat = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
-        elif mode == "zxy":
-            trans_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
-        
-        self.cell = np.dot(self.cell, trans_mat)
-        for i in range(len(self._atoms)):
-            self._atoms[i]._permute_coord(mode=mode)
+        # rotate cartesian coordinates
+        if rotate_cart_coord:
+            self.rotate(trans_mat)
 
+        return trans_mat
 
 def parse_stru_position(pos_line):
     '''


### PR DESCRIPTION
Method to permute axis in AbacusSTRU type structure. Cell, coords, velocities and atom mags (non-collinear case) will be permuted. All two permutations, (x->y, y->z, z->x and x->z, y->x, z->y) are supported.
Cyclic permutation of coordinate axes preserves the handedness of a right-handed coordinate system, whereas a direct transposition (i.e., a single swap) of two coordinate axes reverses the handedness, converting a right-handed system into a left-handed one.